### PR TITLE
32-bit linux platform support(e.g., RPi4)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ use std::ffi::CStr;
 
 /// Represents an entry in `/etc/shadow`
 #[derive(Debug)]
+#[cfg(target_pointer_width = "64")]
 pub struct Shadow {
     /// user login name
     pub name: String,
@@ -58,6 +59,25 @@ pub struct Shadow {
     pub inactive: i64,
     /// date when account expires
     pub expire: i64,
+}
+#[cfg(target_pointer_width = "32")]
+pub struct Shadow {
+    /// user login name
+    pub name: String,
+    /// encrypted password
+    pub password: String,
+    /// last password change
+    pub last_change: i32,
+    /// days until change allowed
+    pub min: i32,
+    /// days before change required
+    pub max: i32,
+    /// days warning for expiration
+    pub warn: i32,
+    /// days before account inactive
+    pub inactive: i32,
+    /// date when account expires
+    pub expire: i32,
 }
 
 impl Shadow {


### PR DESCRIPTION
Try to resolve compile errors in 32bit platform(as below), tested in raspberry-pi4.
```
  --> /cargo/registry/src/github.com-1ecc6299db9ec823/shadow-0.0.1/src/lib.rs:63:26
   |
63 |             last_change: (*spwd).sp_lstchg,
   |                          ^^^^^^^^^^^^^^^^^ expected `i64`, found `i32`

error[E0308]: mismatched types
  --> /cargo/registry/src/github.com-1ecc6299db9ec823/shadow-0.0.1/src/lib.rs:64:18
   |
64 |             min: (*spwd).sp_min,
   |                  ^^^^^^^^^^^^^^ expected `i64`, found `i32`

error[E0308]: mismatched types
  --> /cargo/registry/src/github.com-1ecc6299db9ec823/shadow-0.0.1/src/lib.rs:65:18
   |
65 |             max: (*spwd).sp_max,
   |                  ^^^^^^^^^^^^^^ expected `i64`, found `i32`

error[E0308]: mismatched types
  --> /cargo/registry/src/github.com-1ecc6299db9ec823/shadow-0.0.1/src/lib.rs:66:19
   |
66 |             warn: (*spwd).sp_warn,
   |                   ^^^^^^^^^^^^^^^ expected `i64`, found `i32`

error[E0308]: mismatched types
  --> /cargo/registry/src/github.com-1ecc6299db9ec823/shadow-0.0.1/src/lib.rs:67:23
   |
67 |             inactive: (*spwd).sp_inact,
   |                       ^^^^^^^^^^^^^^^^ expected `i64`, found `i32`

error[E0308]: mismatched types
  --> /cargo/registry/src/github.com-1ecc6299db9ec823/shadow-0.0.1/src/lib.rs:68:21
   |
68 |             expire: (*spwd).sp_expire,
   |                     ^^^^^^^^^^^^^^^^^ expected `i64`, found `i32`

For more information about this error, try `rustc --explain E0308`.
error: could not compile `shadow` due to 6 previous errors
```