### PR TITLE
change i64 types to c_long to compile on 32-bit architectures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,6 @@ extern crate libc;
 use std::ffi::CString;
 use std::ffi::CStr;
 
-
 /// Represents an entry in `/etc/shadow`
 #[derive(Debug)]
 pub struct Shadow {
@@ -47,17 +46,17 @@ pub struct Shadow {
     /// encrypted password
     pub password: String,
     /// last password change
-    pub last_change: i64,
+    pub last_change: libc::c_long,
     /// days until change allowed
-    pub min: i64,
+    pub min: libc::c_long,
     /// days before change required
-    pub max: i64,
+    pub max: libc::c_long,
     /// days warning for expiration
-    pub warn: i64,
+    pub warn: libc::c_long,
     /// days before account inactive
-    pub inactive: i64,
+    pub inactive: libc::c_long,
     /// date when account expires
-    pub expire: i64,
+    pub expire: libc::c_long,
 }
 
 impl Shadow {


### PR DESCRIPTION
On armv7(32 bit) c_long is 32 bit, so use of i64 breaks compilation